### PR TITLE
minor: update dependency link to work with pnpm

### DIFF
--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -25,7 +25,7 @@
     "ajv": "^8.6.2",
     "axios": "^0.21.1",
     "bs58": "^4.0.1",
-    "crypto-pouch": "https://github.com/tahpot/crypto-pouch.git#feature/support-key-import",
+    "crypto-pouch": "git+https://github.com/tahpot/crypto-pouch.git#feature/support-key-import",
     "did-jwt": "^5.6.3",
     "json-schema-ref-parser": "^9.0.9",
     "json-schema-resolve-allof": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,9 +2971,9 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-"crypto-pouch@https://github.com/tahpot/crypto-pouch.git#feature/support-key-import":
+"crypto-pouch@git+https://github.com/tahpot/crypto-pouch.git#feature/support-key-import":
   version "4.0.1"
-  resolved "https://github.com/tahpot/crypto-pouch.git#26b27159a8ea039a2ac9382945fe48ed7bc2ccd9"
+  resolved "git+https://github.com/tahpot/crypto-pouch.git#26b27159a8ea039a2ac9382945fe48ed7bc2ccd9"
   dependencies:
     garbados-crypt "^3.0.0-beta"
     transform-pouch "^2.0.0"


### PR DESCRIPTION
# Summary
Currently, installing the @verida/account-web-vault using pnpm due to incompatible URL format.

# Reproduction
1. Install npm ```npm install pnpm```
2. Create new npm package ```npm init```
3. Install @@verida/account-web-vault with ```pnpm install @verida/account-web-vault```

# Expected
Install package successfully

# Actual
Package failed to be installed. Encountered pnpm error

```

 WARN  GET https://github.com/tahpot/crypto-pouch.git#feature/support-key-import error (undefined). Will retry in 1 minute. 1 retries left.

 ERROR  Invalid tar header. Maybe the tar is corrupted or it needs to be gunzipped? 

```

# Fix
Update dependent package to use ```git+https://``` format which is compatible with both npm, pnpm, and yarn:

```
{
...
"crypto-pouch": "git+https://github.com/tahpot/crypto-pouch.git#feature/support-key-import"
}
```