### PR TITLE
Handle QR modal cancel

### DIFF
--- a/packages/account-web-vault/src/interfaces.ts
+++ b/packages/account-web-vault/src/interfaces.ts
@@ -16,6 +16,7 @@ export interface VaultModalLoginConfig {
     deeplinkId?: string,
     request?: object,        // Authorization request object that matches https://schemas.verida.io/auth/request/schema.json
     callback?(response: AuthResponse): void        // callback function (called when auth response received)
+    callbackRejected?(): void   // callback function (called when user rejects / cancels the login by closing the modal)
 }
 
 export interface AuthClientConfig {
@@ -28,6 +29,7 @@ export interface AuthClientConfig {
     deeplinkId?: string,
     request?: object,        // Authorization request object that matches https://schemas.verida.io/auth/request/schema.json
     callback(response: AuthResponse): void        // callback function (called when auth response received)
+    callbackRejected?(): void   // callback function (called when user rejects / cancels the login by closing the modal)
 }
 
 export interface AuthResponse {

--- a/packages/account-web-vault/src/vault-account.ts
+++ b/packages/account-web-vault/src/vault-account.ts
@@ -50,7 +50,7 @@ export default class VaultAccount extends Account {
             return contextConfig
         }
 
-        const promise = new Promise<void>((resolve, reject) => {
+        const promise = new Promise<boolean>((resolve, reject) => {
             const cb = async (response: any, saveSession: boolean) => {
                 if (saveSession) {
                     let storedSessions = store.get(VERIDA_AUTH_CONTEXT)
@@ -64,11 +64,14 @@ export default class VaultAccount extends Account {
 
                 this.setDid(response.did)
                 vaultAccount.addContext(response.context, response.contextConfig, new Keyring(response.signature))
-                resolve()
+                resolve(true)
             }
 
             const config: VaultModalLoginConfig = _.merge(CONFIG_DEFAULTS, this.config.vaultConfig, {
-                callback: cb
+                callback: cb,
+                callbackRejected: function() {
+                    resolve(false)
+                }
             })
 
             VaultModalLogin(contextName, config)

--- a/packages/account-web-vault/src/vault-modal-login.ts
+++ b/packages/account-web-vault/src/vault-modal-login.ts
@@ -320,12 +320,16 @@ export default async function (contextName: string, config: VaultModalLoginConfi
   }
 
   if (modal && closeModal) {
-    closeModal.onclick = () => modal.style.display = 'none';
+    closeModal.onclick = () => {
+      modal.style.display = 'none';
+      authConfig.callbackRejected!();
+    }
   }
 
   window.onclick = function (event: Event) {
     if (event.target === modal && modal !== null) {
       modal.style.display = 'none';
+      authConfig.callbackRejected!();
     }
   }
 

--- a/packages/client-ts/src/client.ts
+++ b/packages/client-ts/src/client.ts
@@ -109,7 +109,7 @@ export default class Client {
         }
 
         if (!contextConfig) {
-            throw new Error ('Unable to locate requested storage context for requeseted DID. Force create?')
+            throw new Error ('Unable to locate requested storage context for requested DID. Force create?')
         }
 
         // @todo cache the storage contexts

--- a/packages/client-ts/src/network.ts
+++ b/packages/client-ts/src/network.ts
@@ -11,12 +11,19 @@ export default class Network {
      * and then opening a context.
      * 
      * @param config NetworkConnectionConfig Configuration 
-     * @returns 
+     * @returns {Context | undefined} If the user logs in a valid `Context` object is returned. If an unexpected error occurs or the user cancels the login attempt then nothing is returned.
      */
     public static async connect(config: NetworkConnectionConfig): Promise<Context | undefined> {
         const client = new Client(config.client ? config.client : {})
         await client.connect(config.account)
-        return client.openContext(config.context.name, config.context.forceCreate)
+
+        try {
+            const context = await client.openContext(config.context.name, config.context.forceCreate)
+            return context
+        } catch (err) {
+            // User may have cancelled the login attempt
+            return
+        }
     }
 
 }


### PR DESCRIPTION
Detect when a user closes the QR code login modal and ensure the login promise resolves with a `false` response.

Resolves #72.