### PR TITLE
API Docs deployment script

### DIFF
--- a/packages/client-ts/generate-and-deploy-docs.sh
+++ b/packages/client-ts/generate-and-deploy-docs.sh
@@ -1,0 +1,23 @@
+# To use this you will need to set an named AWS profile.
+# Docs are at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+#
+# Something like this works 
+#   export AWS_PROFILE=verida-prod
+#
+
+if [[ -z "$AWS_PROFILE" ]]; then
+    echo "You need to set AWS_PROFILE to use this script" 1>&2
+    exit 1
+fi
+
+
+
+# make sure the docs are up to date
+rm -rf api-docs
+yarn generate-api-docs
+
+# This copys from the build target directory to S3
+aws s3 sync api-docs s3://apidocs.verida.io --delete
+
+# And now we invalidate the cached cloudfront distribution so changes are available
+aws cloudfront create-invalidation --distribution-id E1L1Y2VRSXQCBR  --paths "/*"


### PR DESCRIPTION
Deployment script. 

Since our library deployment is done manually (ie, not based on a merge to a branch) it probably makes sense to manually deploy docs too for now. 

Script is tested and deploys to https://apidocs.verida.io/