### PR TITLE
Add real credentials data in test case

### DIFF
--- a/packages/verifiable-credentials/src/credentials.ts
+++ b/packages/verifiable-credentials/src/credentials.ts
@@ -168,11 +168,19 @@ export default class Credentials {
 
 		// Ensure data matches specified schema
 		const schema = await this.context.getClient().getSchema(data.schema)
-		const isValid = await schema.validate(data);
+
+		// Before validating, we need to ensure there is a `didJwtVc` attribute on the data
+		// `didJwtVc` is a required field, but will only be set upon completion of this
+		// creation process.
+		// @see https://github.com/verida/verida-js/pull/163
+		const dataClone = Object.assign({}, data);
+		dataClone['didJwtVc'] = 'ABC'
+		const isValid = await schema.validate(dataClone);
 
 		// @todo: Check the schema is a "credential" schema type?
 
 		if (!isValid) {
+			this.errors = schema.errors
 			throw new Error('Data does not match specified schema')
 		}
 

--- a/packages/verifiable-credentials/test/config.ts
+++ b/packages/verifiable-credentials/test/config.ts
@@ -30,6 +30,17 @@ export const config = {
         email: 'me@vitalik.eth',
         schema: 'https://common.schemas.verida.io/social/contact/v0.1.0/schema.json',
         didJwtVc: 'eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInN1YiI6ImRpZDp2ZGE6MHhDMjYyOTk4MkEyNTg1NTQ0RkQ3MmM5OUNGMzc3M2E5YzZiYUJENTVjIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJkaWQ6dmRhOjB4QjM3Mjk5ODJBMjU4NTU0NEZENzJjOTlDRjM3NzNhOWM2YmFCRDU1YyIsImlzc3VhbmNlRGF0ZSI6IjIwMjItMDItMjNUMDY6NDE6NTUuMDk3WiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOiJWaXRhbGlrIEJ1dGVyaW4iLCJmaXJzdE5hbWUiOiJWaXRhbGlrIiwibGFzdE5hbWUiOiJCdXRlcmluIiwiZW1haWwiOiJtZUB2aXRhbGlrLmV0aCIsInNjaGVtYSI6Imh0dHBzOi8vY29tbW9uLnNjaGVtYXMudmVyaWRhLmlvL3NvY2lhbC9jb250YWN0L3YwLjEuMC9zY2hlbWEuanNvbiJ9LCJjcmVkZW50aWFsU2NoZW1hIjp7ImlkIjoiaHR0cHM6Ly9jb21tb24uc2NoZW1hcy52ZXJpZGEuaW8vc29jaWFsL2NvbnRhY3QvdjAuMS4wL3NjaGVtYS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In19LCJpc3MiOiJkaWQ6dmRhOjB4QjM3Mjk5ODJBMjU4NTU0NEZENzJjOTlDRjM3NzNhOWM2YmFCRDU1YyJ9.BdokafCkVKavdVM2UgAnCTY4pUlpQ02-7bi5FtKK0Wgvwo2xfpps17qa1iuWa9IsmzgYcB4R8SlBgpybQ5AW_w'
+    },
+    CREDENTIAL_DATA_PAYLOAD: {
+        firstName: "Hien",
+        healthType: "Dentist",
+        lastName: "Phung",
+        name: "Your Dentist Credential",
+        regExpDate: "2022-03-31",
+        regNumber: "12131",
+        schema: "https://verida.github.io/demo-credential-issuer/mapay/v0.1.0/schema.json",
+        summary: "Credential issued at Tue Mar 01 2022",
+        testTimestamp: "2022-03-01T10:30:05.435Z"
     }
 }
 

--- a/packages/verifiable-credentials/test/create-credentials.test.ts
+++ b/packages/verifiable-credentials/test/create-credentials.test.ts
@@ -18,7 +18,7 @@ describe('Credential tests', function () {
         });
         it('Verify Credential JWT was created correctly', async function () {
 
-            const jwt: any = await credential.createCredentialJWT(config.SUBJECT_DID, config.CREDENTIAL_DATA);
+            const jwt: any = await credential.createCredentialJWT(config.SUBJECT_DID, config.CREDENTIAL_DATA_PAYLOAD);
 
             const issuer = await credential.createIssuer();
 

--- a/packages/verifiable-credentials/test/create-credentials.test.ts
+++ b/packages/verifiable-credentials/test/create-credentials.test.ts
@@ -32,19 +32,19 @@ describe('Credential tests', function () {
             // Verify the "Payload"
             assert.equal(payload.iss, issuer.did, 'Credential issuer matches expected DID')
 
-            // Verify the "Verifiable Credential"
-            delete config.CREDENTIAL_DATA['didJwtVc']
-
-            assert.deepEqual(vc.credentialSubject, config.CREDENTIAL_DATA, 'Credential data is valid');
-            assert.deepEqual(issuer.did, vc.issuer, 'Issuer matches expected DID');
-            assert.equal(vc.credentialSchema.id, config.CREDENTIAL_DATA.schema, 'Credential schema is correct')
-            assert.equal(vc.sub, config.SUBJECT_DID, 'Credential subject matches expected DID')
-
             // Verify the data matches the schema
             const record = vc.credentialSubject
             const schema = await appContext.getClient().getSchema(record.schema)
-            const isValid = await schema.validate(config.CREDENTIAL_DATA);
+            const isValid = await schema.validate(config.CREDENTIAL_DATA_PAYLOAD);
             assert.equal(true, isValid, 'Credential subject successfully validates against the schema');
+
+            // Verify the "Verifiable Credential"
+            delete config.CREDENTIAL_DATA_PAYLOAD['didJwtVc']
+
+            assert.deepEqual(vc.credentialSubject, config.CREDENTIAL_DATA_PAYLOAD, 'Credential data is valid');
+            assert.deepEqual(issuer.did, vc.issuer, 'Issuer matches expected DID');
+            assert.equal(vc.credentialSchema.id, config.CREDENTIAL_DATA_PAYLOAD.schema, 'Credential schema is correct')
+            assert.equal(vc.sub, config.SUBJECT_DID, 'Credential subject matches expected DID')
         });
         it('Unable to create credential with invalid schema data', async function () {
             const promise = new Promise((resolve, rejects) => {


### PR DESCRIPTION
In https://github.com/verida/demo-credential-issuer/issues/39, we need to create the `didJwtVc` property based on the data user filled in the form.
Currently when the app calls `credential.createCredentialJWT()` (full example: https://github.com/verida/demo-credential-issuer/blob/96629599c9fad62c5d539435871b24323e00ee99/src/helpers/VeridaClient.helpers.ts#L21), it will throw this error:
```
credentials.js?757d:246 Uncaught (in promise) Error: Data does not match specified schema
    at Credentials.eval (credentials.js?757d:246:1)
    at step (credentials.js?757d:44:1)
    at Object.eval [as next] (credentials.js?757d:25:1)
    at fulfilled (credentials.js?757d:16:1)
```
The current test case in this PR is for reproducing and debugging this issue.