### PR TITLE
Fix/190 get many return array. Closes 190

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ipfs
 node_modules
 .DS_Store
 *.log
+api-docs

--- a/packages/client-ts/src/context/engines/verida/database/base-db.ts
+++ b/packages/client-ts/src/context/engines/verida/database/base-db.ts
@@ -230,7 +230,8 @@ class BaseDb extends EventEmitter implements Database {
       return raw ? docs : docs.docs;
     }
 
-    return;
+    // CouchDb returned something falsey
+    return [];
   }
 
   public async delete(doc: any, options: any = {}) {


### PR DESCRIPTION
getMany() currently returns undefined if CouchDB returns falsey. @tahpot suggested it should return a zero-length array in those circumstances. 

This PR implements that. 