### PR TITLE
Add an extra param `fallbackContext` to `openPublicProfile` method default value to `Verida: Vault`

### DIFF
--- a/packages/client-ts/src/client.ts
+++ b/packages/client-ts/src/client.ts
@@ -208,7 +208,7 @@ class Client {
   ): Promise<Profile | undefined> {
     let context: Context | undefined;
     try {
-      context = await this.openContext(contextName, false);
+      context = await this.openExternalContext(contextName, did);
     } catch (error) {
       if (fallbackContext) {
         return await this.openPublicProfile(did, fallbackContext, profileName, undefined);

--- a/packages/client-ts/test/profile.tests.ts
+++ b/packages/client-ts/test/profile.tests.ts
@@ -42,7 +42,7 @@ describe('Profile tests', () => {
             assert.equal(name, DATA.name, "Can set and get a profile value")
         })
 
-        it('can not set invalid profile values', async () => {
+        it.skip('can not set invalid profile values', async () => {
             context1 = await client1.openContext(CONFIG.CONTEXT_NAME, true)
 
             profile1 = await context1.openProfile()
@@ -50,7 +50,7 @@ describe('Profile tests', () => {
             assert.equal(response, false, "Can not set an invalid profile value")
         })
 
-        it('can access an external profile', async () => {
+        it.skip('can access an external profile', async () => {
             const account2 = new AutoAccount(CONFIG.DEFAULT_ENDPOINTS, {
                 privateKey: CONFIG.VDA_PRIVATE_KEY_2,
                 environment: CONFIG.ENVIRONMENT,
@@ -64,6 +64,45 @@ describe('Profile tests', () => {
             const name = await profile2.get("name")
             assert.equal(name, DATA.name, "Can get external public profile data")
         })
+
+        describe("Using Client to open public profiles", function () {
+            const wrongContextName = "Context: Wrong Name";
+
+            it('can use fallbackContext="Verida: Vault" to open public profile', async () => {
+                const profile = await client1.openPublicProfile(
+                    did1,
+                    wrongContextName
+                );
+                const name = await profile.get("name");
+
+                assert.equal(name, DATA.name, "Can get a profile value");
+            });
+
+            it("can disable fallbackContext on open public profile", async () => {
+                const profile = await client1.openPublicProfile(
+                    did1,
+                    CONFIG.CONTEXT_NAME,
+                    "basicProfile",
+                    null
+                );
+                const name = await profile.get("name");
+
+                assert.equal(name, DATA.name, "Can get a profile value");
+            });
+
+            it("can not open a public profile using the wrong context and without fallbackContext option", async () => {
+                await assert.rejects(async () => {
+                    await client1.openPublicProfile(
+                        did1,
+                        wrongContextName,
+                        "basicProfile",
+                        null
+                    );
+                }, {
+                    message: `Wrong context - ${wrongContextName}`
+                })
+            });
+        });
     })
 
     // @todo: add tests for private profiles

--- a/packages/client-ts/test/profile.tests.ts
+++ b/packages/client-ts/test/profile.tests.ts
@@ -99,8 +99,8 @@ describe('Profile tests', () => {
                         null
                     );
                 }, {
-                    message: `Wrong context - ${wrongContextName}`
-                })
+                    message: `Account does not have a public profile for ${wrongContextName}`
+                }, 'can not open public profile')
             });
         });
     })

--- a/packages/client-ts/test/profile.tests.ts
+++ b/packages/client-ts/test/profile.tests.ts
@@ -42,7 +42,7 @@ describe('Profile tests', () => {
             assert.equal(name, DATA.name, "Can set and get a profile value")
         })
 
-        it.skip('can not set invalid profile values', async () => {
+        it('can not set invalid profile values', async () => {
             context1 = await client1.openContext(CONFIG.CONTEXT_NAME, true)
 
             profile1 = await context1.openProfile()
@@ -50,7 +50,7 @@ describe('Profile tests', () => {
             assert.equal(response, false, "Can not set an invalid profile value")
         })
 
-        it.skip('can access an external profile', async () => {
+        it('can access an external profile', async () => {
             const account2 = new AutoAccount(CONFIG.DEFAULT_ENDPOINTS, {
                 privateKey: CONFIG.VDA_PRIVATE_KEY_2,
                 environment: CONFIG.ENVIRONMENT,


### PR DESCRIPTION
## Changes

- Add an extra param `fallbackContext` to `openPublicProfile` method default value to `Verida: Vault`
- Add tests

Issue: https://github.com/verida/verida-js/issues/194