### PR TITLE
Fix infinite recursion cause of set `undefined` to `fallbackContext`

### DIFF
--- a/packages/client-ts/src/client.ts
+++ b/packages/client-ts/src/client.ts
@@ -204,14 +204,14 @@ class Client {
     did: string,
     contextName: string,
     profileName: string = "basicProfile",
-    fallbackContext: string | undefined = "Verida: Vault"
+    fallbackContext: string | null = "Verida: Vault"
   ): Promise<Profile | undefined> {
     let context: Context | undefined;
     try {
       context = await this.openExternalContext(contextName, did);
     } catch (error) {
       if (fallbackContext) {
-        return await this.openPublicProfile(did, fallbackContext, profileName, undefined);
+        return await this.openPublicProfile(did, fallbackContext, profileName, null);
       }
     }
 

--- a/packages/client-ts/test/profile.tests.ts
+++ b/packages/client-ts/test/profile.tests.ts
@@ -67,6 +67,7 @@ describe('Profile tests', () => {
 
         describe("Using Client to open public profiles", function () {
             const wrongContextName = "Context: Wrong Name";
+            const wrongFallbackContextName = "Context: Wrong Name 2";
 
             it('can use fallbackContext="Verida: Vault" to open public profile', async () => {
                 const profile = await client1.openPublicProfile(
@@ -90,7 +91,7 @@ describe('Profile tests', () => {
                 assert.equal(name, DATA.name, "Can get a profile value");
             });
 
-            it("can not open a public profile using the wrong context and without fallbackContext option", async () => {
+            it("can not open a public profile using the wrong context and without fallbackContext", async () => {
                 await assert.rejects(async () => {
                     await client1.openPublicProfile(
                         did1,
@@ -100,7 +101,20 @@ describe('Profile tests', () => {
                     );
                 }, {
                     message: `Account does not have a public profile for ${wrongContextName}`
-                }, 'can not open public profile')
+                })
+            });
+
+            it("can not open a public profile using both the wrong context and wrong fallbackContext", async () => {
+                await assert.rejects(async () => {
+                    await client1.openPublicProfile(
+                        did1,
+                        wrongContextName,
+                        "basicProfile",
+                        wrongFallbackContextName
+                    );
+                }, {
+                    message: `Account does not have a public profile for ${wrongFallbackContextName}`
+                })
             });
         });
     })


### PR DESCRIPTION
## Changes
- Hotfix infinite recursion cause of set `undefined` to `fallbackContext`
- Add test

```
public async openPublicProfile(
    did: string,
    contextName: string,
    profileName: string = "basicProfile",
    fallbackContext: string | null = "Verida: Vault"
  ): Promise<Profile | undefined> {
    let context: Context | undefined;
    try {
      context = await this.openExternalContext(contextName, did);
    } catch (error) {
      if (fallbackContext) {
        // !!! Set `undefined` to the fourth param of function has no effect, the default value will be picked up anyway
        return await this.openPublicProfile(did, fallbackContext, profileName, undefined); 

        // Change to this
        // return await this.openPublicProfile(did, fallbackContext, profileName, null);  <= Null
      }
    }

    if (!context) {
      throw new Error(
        `Account does not have a public profile for ${contextName}`
      );
    }

    return context!.openProfile(profileName, did, false);
  }
```