### PR TITLE
Fix/332 `WebUser` using previous identity after disconnecting and connecting with a different one

### DIFF
--- a/packages/web-helpers/CHANGELOG.md
+++ b/packages/web-helpers/CHANGELOG.md
@@ -1,3 +1,8 @@
+2023-xx-xx (c2.3.x)
+-------------------
+
+- Fix `WebUser` using using previous Identity profile after disconnecting and connecting with a different one.
+
 2023-04-20 (v2.3.0)
 -------------------
 

--- a/packages/web-helpers/src/WebUser.ts
+++ b/packages/web-helpers/src/WebUser.ts
@@ -219,6 +219,7 @@ export class WebUser extends EventEmitter {
             this.account = undefined
             this.did = undefined
             this.profile = undefined
+            this.profileConnection = undefined
             this.connecting = undefined
 
             if (this.config.debug) {


### PR DESCRIPTION
The `disconnect` method was not cleaning the `profileConnection` instance property that is used to get the profile.