### PR TITLE
Fix/347 - Fix `WebUser.connect` crashing when getting public profile

### DIFF
--- a/packages/web-helpers/src/WebUser.ts
+++ b/packages/web-helpers/src/WebUser.ts
@@ -221,17 +221,15 @@ export class WebUser extends EventEmitter {
             }
 
             const did = await account.did()
+            this.did = did
+            this.account = account
+            this.context = context
+            this.client = context.getClient()
             if (config.debug) {
                 console.log(`Account connected with did: ${did}`)
             }
 
             const profile = await this.getPublicProfile()
-
-            this.account = account
-            this.context = context
-            this.did = did
-            this.client = context.getClient()
-
             this.emit('connected', profile)
             resolve(true)
         })


### PR DESCRIPTION
The `WebUser.connect` is calling `this.getPublicProfile` method before setting all the instance variables indicating a successful connection (`this.did`, `this.account` and `this.context`).

As `this.getPublicProfile` checks if these variables are present (via `this.requireConnection`), it throws an error.