### PR TITLE
Add the missing `environment` property to `AccountVaultRequest`

### DIFF
--- a/packages/types/src/AccountInterfaces.ts
+++ b/packages/types/src/AccountInterfaces.ts
@@ -64,6 +64,10 @@ export interface WalletConnectConfig {
 }
 
 export interface AccountVaultRequest {
+    /**
+     * Optional, environment to use for the request, should match the expected environment of Application
+     */
+    environment?: EnvironmentType,
     logoUrl?: string,       // Optional URL that will be displayed as part of the login process
     openUrl?: string,       // Optional URL that will be opened on the user's mobile device once the user is logged in
     walletConnect?: {       // Optional, WalletConnect configuration to enable a seamless connection with both Verida and WalletConnect with a single request


### PR DESCRIPTION
@tahpot I added the missing property.

I put it as optional for backward compatibility.

But it should be required. In that case, it's be in a Major version 3.0.0, which would make sense with the Mainnet being the default, which is a breaking change.