### PR TITLE
Fix migration opening database with wrong config

### DIFF
--- a/packages/client-ts/src/utils/migration.ts
+++ b/packages/client-ts/src/utils/migration.ts
@@ -51,7 +51,6 @@ async function _migrateContext(sourceContext: IContext, destinationContext: ICon
             }
             const destinationDb = await destinationContext.openDatabase(sourceDbInfo.databaseName, destinationConfig)
 
-            console.debug('migration.ts - _migrateContext - Execute DB migration')
             // Migrate data
             await migrateDatabase(sourceDb, destinationDb)
 
@@ -80,7 +79,7 @@ export async function migrateDatabase(sourceDb: IDatabase, destinationDb: IDatab
     } else {
         sourceCouchDb = await sourceDb.getDb()
         destinationCouchDb = await destinationDb.getDb()
-    }``
+    }
 
     // Don't catch replication errors, allow them to bubble up
     await sourceCouchDb.replicate.to(destinationCouchDb)


### PR DESCRIPTION
Both the source database and destination database were passed the same config object
```ts
const config = {
    permissions: sourceDbInfo.permissions,
    verifyEncryptionKey: false
}
```
Problem was the `...Context.openDatabase(databaseName, config)` mutates the config object to add the DID if missing or use it if available.
So the `sourceContext.openDatabase` would add the source DID to the shared config object and when opening the destination database, the same DID from the source was used instead of the destination DID.