### PR TITLE
Fix typos: correct spelling 

### DIFF
--- a/packages/client-ts/test/storage.endpoints.tests.ts
+++ b/packages/client-ts/test/storage.endpoints.tests.ts
@@ -166,7 +166,7 @@ describe.skip('Storage endpoint tests', () => {
             assert.deepEqual(databaseList[ENDPOINT_1], databaseList[ENDPOINT_2], 'Endpoints have the same database list')
 
             // Confirm database usage matches
-            // Note: Often small discrepancies, so this tst is ignroed
+            // Note: Often small discrepancies, so this tst is ignored
             // console.log(usage)
             //assert.deepEqual(usage[ENDPOINT_1], usage[ENDPOINT_2], 'Endpoints have the same usage stats')
         })

--- a/packages/vda-web3-client/README.md
+++ b/packages/vda-web3-client/README.md
@@ -57,7 +57,7 @@ Configurations are a bit different for both modes:
 ```
 
 ## Interacting with Contract
-Developers can call any contract functions using instace created above.
+Developers can call any contract functions using instance created above.
 ```
 const ret = instance.identityOwner('0x12...5f')
 ```

--- a/packages/vda-web3-client/src/utils.ts
+++ b/packages/vda-web3-client/src/utils.ts
@@ -26,7 +26,7 @@ export function isVeridaContract(contractAddress: string) : boolean {
 
 /**
  * Get Polygon fee data to send the transactions
- * @param gasStationUrl Gas station url to pull the gas inforamtion
+ * @param gasStationUrl Gas station url to pull the gas information
  * @returns Matic fee data
  */
 export async function getMaticFee(gasStationUrl: string, mode: string) {


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- Corrects "ignroed" to "ignored" in storage endpoints test
- Fixes "inforamtion" to "information" in JSDoc comment
- Fixes "instace" to "instance" in README.md

These changes are purely cosmetic and do not affect functionality.